### PR TITLE
Refactor flags to use proper Cobra patterns and add global --endpoint, --api-key flags

### DIFF
--- a/cmd/logs/attributes.go
+++ b/cmd/logs/attributes.go
@@ -34,7 +34,6 @@ var (
 	attributesRegexFilters []string
 	attributesStartTime    string
 	attributesEndTime      string
-	attributesNoColor      bool
 	attributesAppName      string
 	attributesLogLevel     string
 )
@@ -60,24 +59,25 @@ func init() {
 	AttributesCmd.Flags().StringSliceVarP(&attributesRegexFilters, "regex", "r", []string{}, "Regex filter in format 'key:value' (can be used multiple times)")
 	AttributesCmd.Flags().StringVarP(&attributesStartTime, "start", "s", "", "Start time (e.g., 'e-1h', '2024-01-01T00:00:00Z')")
 	AttributesCmd.Flags().StringVarP(&attributesEndTime, "end", "e", "", "End time (e.g., 'now', '2024-01-01T23:59:59Z')")
-	AttributesCmd.Flags().BoolVar(&attributesNoColor, "no-color", false, "Disable colored output")
 	AttributesCmd.Flags().StringVarP(&attributesAppName, "app", "a", "", "Filter by application/service name")
 	AttributesCmd.Flags().StringVarP(&attributesLogLevel, "level", "l", "", "Filter by log level (e.g., ERROR, INFO, DEBUG, WARN)")
 
 	TagValuesCmd.Flags().StringSliceVarP(&attributesFilters, "filter", "f", []string{}, "Filter in format 'key:value' (can be used multiple times)")
 	TagValuesCmd.Flags().StringVarP(&attributesStartTime, "start", "s", "", "Start time (e.g., 'e-1h', '2024-01-01T00:00:00Z')")
 	TagValuesCmd.Flags().StringVarP(&attributesEndTime, "end", "e", "", "End time (e.g., 'now', '2024-01-01T23:59:59Z')")
-	TagValuesCmd.Flags().BoolVar(&attributesNoColor, "no-color", false, "Disable colored output")
 	TagValuesCmd.Flags().StringVarP(&attributesAppName, "app", "a", "", "Filter by application/service name")
 	TagValuesCmd.Flags().StringVarP(&attributesLogLevel, "level", "l", "", "Filter by log level (e.g., ERROR, INFO, DEBUG, WARN)")
 }
 
-func runAttributesCmd(_ *cobra.Command, targets []string) error {
+func runAttributesCmd(cmdObj *cobra.Command, targets []string) error {
+	noColor, _ := cmdObj.Flags().GetBool("no-color")
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		attributesNoColor = true
+		noColor = true
 	}
 
-	cfg, err := config.Load()
+	endpoint, _ := cmdObj.Flags().GetString("endpoint")
+	apiKey, _ := cmdObj.Flags().GetString("api-key")
+	cfg, err := config.LoadWithFlags(endpoint, apiKey)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -246,7 +246,7 @@ func runAttributesCmd(_ *cobra.Command, targets []string) error {
 				if tagName != "" && !tagsSet[tagName] {
 					tagsSet[tagName] = true
 
-					if attributesNoColor {
+					if noColor {
 						fmt.Printf("%s\n", tagName)
 					} else {
 						fmt.Printf("\033[36m%s\033[0m\n", tagName)
@@ -265,12 +265,15 @@ func runAttributesCmd(_ *cobra.Command, targets []string) error {
 	return nil
 }
 
-func runTagValuesCmd(_ *cobra.Command, args []string) error {
+func runTagValuesCmd(cmdObj *cobra.Command, args []string) error {
+	noColor, _ := cmdObj.Flags().GetBool("no-color")
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		attributesNoColor = true
+		noColor = true
 	}
 
-	cfg, err := config.Load()
+	endpoint, _ := cmdObj.Flags().GetString("endpoint")
+	apiKey, _ := cmdObj.Flags().GetString("api-key")
+	cfg, err := config.LoadWithFlags(endpoint, apiKey)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -385,7 +388,7 @@ func runTagValuesCmd(_ *cobra.Command, args []string) error {
 				if tagValue != "" && !valuesSet[tagValue] {
 					valuesSet[tagValue] = true
 
-					if attributesNoColor {
+					if noColor {
 						fmt.Printf("%s\n", tagValue)
 					} else {
 						fmt.Printf("\033[36m%s\033[0m\n", tagValue)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,10 +20,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	verbose bool
-	quiet   bool
-)
 
 var rootCmd = &cobra.Command{
 	Use:   "lakerunner",
@@ -35,14 +31,13 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
-// IsQuiet returns the value of the quiet flag
-func IsQuiet() bool {
-	return quiet
-}
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
-	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress informational output")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "suppress informational output")
+	rootCmd.PersistentFlags().Bool("no-color", false, "disable colored output")
+	rootCmd.PersistentFlags().String("endpoint", "", "API endpoint URL (overrides LAKERUNNER_QUERY_URL)")
+	rootCmd.PersistentFlags().String("api-key", "", "API key (overrides LAKERUNNER_API_KEY)")
 
 	rootCmd.AddCommand(logs.LogsCmd)
 	rootCmd.AddCommand(demo.DemoCmd)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,15 @@ func Load() (*Config, error) {
 	return cfg, cfg.Validate()
 }
 
+// LoadWithFlags loads configuration with optional flag overrides
+func LoadWithFlags(endpointFlag, apiKeyFlag string) (*Config, error) {
+	cfg := &Config{
+		LAKERUNNER_QUERY_URL: getEnvOrFlag("LAKERUNNER_QUERY_URL", endpointFlag),
+		LAKERUNNER_API_KEY:   getEnvOrFlag("LAKERUNNER_API_KEY", apiKeyFlag),
+	}
+	return cfg, cfg.Validate()
+}
+
 func getEnv(key, fallback string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
@@ -39,12 +48,20 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
+// getEnvOrFlag returns flag value if provided, otherwise falls back to environment variable
+func getEnvOrFlag(envKey, flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	return getEnv(envKey, "")
+}
+
 func (c *Config) Validate() error {
 	if c.LAKERUNNER_QUERY_URL == "" {
-		return fmt.Errorf("LAKERUNNER_QUERY_URL environment variable is required")
+		return fmt.Errorf("API endpoint is required: set LAKERUNNER_QUERY_URL environment variable or use --endpoint flag")
 	}
 	if c.LAKERUNNER_API_KEY == "" {
-		return fmt.Errorf("LAKERUNNER_API_KEY environment variable is required")
+		return fmt.Errorf("API key is required: set LAKERUNNER_API_KEY environment variable or use --api-key flag")
 	}
 	return nil
 }


### PR DESCRIPTION
Converts --no-color to global flag using Cobra's persistent flags, adds --endpoint and --api-key global flags, and improves error messages to mention flag alternatives.