### PR TITLE
Fix log queries against current schema and stray done-event row

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ lakerunner logs get -s e-24h --limit 50000 -o csv > yesterday.csv
 ```
 
 See the [full CLI reference](https://docs.cardinalhq.io/lakerunner/cli) for all flags, output formats, presets, aliases, and more.
+
+## Building from source
+
+Requires Go 1.24+.
+
+```sh
+git clone https://github.com/cardinalhq/lakerunner-cli.git
+cd lakerunner-cli
+make local        # produces ./bin/lakerunner-cli
+make check        # go test -race + license-check + golangci-lint
+```

--- a/cmd/logs/attributes.go
+++ b/cmd/logs/attributes.go
@@ -174,10 +174,10 @@ func runTagValuesCmd(cmdObj *cobra.Command, args []string) error {
 
 	var conditions []string
 	if attributesAppName != "" {
-		conditions = append(conditions, fmt.Sprintf(`resource_service_name="%s"`, normalizeTag(attributesAppName)))
+		conditions = append(conditions, fmt.Sprintf(`service="%s"`, normalizeTag(attributesAppName)))
 	}
 	if attributesLogLevel != "" {
-		conditions = append(conditions, fmt.Sprintf(`_cardinalhq_level="%s"`, normalizeTag(attributesLogLevel)))
+		conditions = append(conditions, fmt.Sprintf(`level="%s"`, normalizeTag(attributesLogLevel)))
 	}
 	for _, f := range allFilters {
 		if parts := strings.SplitN(f, ":", 2); len(parts) == 2 {

--- a/cmd/logs/get.go
+++ b/cmd/logs/get.go
@@ -82,28 +82,28 @@ func getFieldValue(message map[string]any, tags map[string]any, field string) st
 		return ""
 	case "level":
 		if tags != nil {
-			if level, ok := tags["log_level"].(string); ok {
+			if level, ok := tags["level"].(string); ok {
 				return level
 			}
 		}
 		return ""
 	case "message":
 		if tags != nil {
-			if msg, ok := tags["log_message"].(string); ok {
+			if msg, ok := tags["message"].(string); ok {
 				return msg
 			}
 		}
 		return ""
 	case "service", "svc":
 		if tags != nil {
-			if service, ok := tags["resource_service_name"].(string); ok {
+			if service, ok := tags["service"].(string); ok {
 				return service
 			}
 		}
 		return ""
 	case "pod":
 		if tags != nil {
-			if pod, ok := tags["resource_k8s_pod_name"].(string); ok {
+			if pod, ok := tags["k8s_pod_name"].(string); ok {
 				return pod
 			}
 		}
@@ -140,8 +140,8 @@ func formatCSVRow(values []string, delimiter string) string {
 }
 
 // buildAppCondition builds a LogQL condition for service name filtering
-// Single app: resource_service_name="app"
-// Multiple apps: resource_service_name=~"app1|app2|app3"
+// Single app: service="app"
+// Multiple apps: service=~"app1|app2|app3"
 func buildAppCondition(appName string) string {
 	apps := strings.Split(appName, ",")
 	// Filter and normalize app names
@@ -156,10 +156,10 @@ func buildAppCondition(appName string) string {
 		return ""
 	}
 	if len(normalized) == 1 {
-		return fmt.Sprintf(`resource_service_name="%s"`, normalized[0])
+		return fmt.Sprintf(`service="%s"`, normalized[0])
 	}
 	// Multiple apps: use regex match
-	return fmt.Sprintf(`resource_service_name=~"%s"`, strings.Join(normalized, "|"))
+	return fmt.Sprintf(`service=~"%s"`, strings.Join(normalized, "|"))
 }
 
 // buildLogQLQuery constructs a LogQL query from filter parameters
@@ -171,7 +171,7 @@ func buildLogQLQuery(appName, logLevel string, filters []string, messageContains
 		}
 	}
 	if logLevel != "" {
-		conditions = append(conditions, fmt.Sprintf(`log_level="%s"`, normalizeTag(logLevel)))
+		conditions = append(conditions, fmt.Sprintf(`level="%s"`, normalizeTag(logLevel)))
 	}
 	for _, f := range filters {
 		parts := strings.SplitN(f, ":", 2)
@@ -182,7 +182,7 @@ func buildLogQLQuery(appName, logLevel string, filters []string, messageContains
 		}
 	}
 
-	q := `{resource_service_name=~".+"}`
+	q := `{service=~".+"}`
 	if len(conditions) > 0 {
 		q = "{" + strings.Join(conditions, ", ") + "}"
 	}
@@ -461,16 +461,16 @@ func runGetCmd(cmdObj *cobra.Command, _ []string) error {
 			levelVal := ""
 			podName := ""
 			if tags != nil {
-				if msg, ok := tags["log_message"].(string); ok {
+				if msg, ok := tags["message"].(string); ok {
 					logMessage = msg
 				}
-				if service, ok := tags["resource_service_name"].(string); ok {
+				if service, ok := tags["service"].(string); ok {
 					serviceName = service
 				}
-				if level, ok := tags["log_level"].(string); ok {
+				if level, ok := tags["level"].(string); ok {
 					levelVal = level
 				}
-				if pod, ok := tags["resource_k8s_pod_name"].(string); ok {
+				if pod, ok := tags["k8s_pod_name"].(string); ok {
 					podName = pod
 				}
 			}

--- a/cmd/logs/get_test.go
+++ b/cmd/logs/get_test.go
@@ -32,18 +32,18 @@ var mockLogEntries = []struct {
 			"timestamp":    int64(1771022549165),
 			"timestamp_ns": int64(1771022549165115500),
 			"tags": map[string]any{
-				"log_level":             "INFO",
-				"log_message":           "GetCartAsync called with userId={userId}",
-				"resource_service_name": "cartservice",
-				"resource_k8s_pod_name": "otel-demo-cartservice-744fc69cf7-bmm9z",
+				"level":             "INFO",
+				"message":           "GetCartAsync called with userId={userId}",
+				"service": "cartservice",
+				"k8s_pod_name": "otel-demo-cartservice-744fc69cf7-bmm9z",
 				"trace_id":              "fa80431d09e856c223bc3f691d0869e7",
 			},
 		},
 		tags: map[string]any{
-			"log_level":             "INFO",
-			"log_message":           "GetCartAsync called with userId={userId}",
-			"resource_service_name": "cartservice",
-			"resource_k8s_pod_name": "otel-demo-cartservice-744fc69cf7-bmm9z",
+			"level":             "INFO",
+			"message":           "GetCartAsync called with userId={userId}",
+			"service": "cartservice",
+			"k8s_pod_name": "otel-demo-cartservice-744fc69cf7-bmm9z",
 			"trace_id":              "fa80431d09e856c223bc3f691d0869e7",
 		},
 	},
@@ -53,18 +53,18 @@ var mockLogEntries = []struct {
 			"timestamp":    int64(1771019896965),
 			"timestamp_ns": int64(1771019896965957376),
 			"tags": map[string]any{
-				"log_level":             "ERROR",
-				"log_message":           "Error ErrorCode.GENERAL while evaluating flag with key: 'loadgeneratorFloodHomepage'",
-				"resource_service_name": "loadgenerator",
-				"resource_k8s_pod_name": "otel-demo-loadgenerator-6b44d87f55-kng6x",
+				"level":             "ERROR",
+				"message":           "Error ErrorCode.GENERAL while evaluating flag with key: 'loadgeneratorFloodHomepage'",
+				"service": "loadgenerator",
+				"k8s_pod_name": "otel-demo-loadgenerator-6b44d87f55-kng6x",
 				"attr_exception_type":   "GeneralError",
 			},
 		},
 		tags: map[string]any{
-			"log_level":             "ERROR",
-			"log_message":           "Error ErrorCode.GENERAL while evaluating flag with key: 'loadgeneratorFloodHomepage'",
-			"resource_service_name": "loadgenerator",
-			"resource_k8s_pod_name": "otel-demo-loadgenerator-6b44d87f55-kng6x",
+			"level":             "ERROR",
+			"message":           "Error ErrorCode.GENERAL while evaluating flag with key: 'loadgeneratorFloodHomepage'",
+			"service": "loadgenerator",
+			"k8s_pod_name": "otel-demo-loadgenerator-6b44d87f55-kng6x",
 			"attr_exception_type":   "GeneralError",
 		},
 	},
@@ -74,17 +74,17 @@ var mockLogEntries = []struct {
 			"timestamp":    int64(1771022489921),
 			"timestamp_ns": int64(1771022489921509376),
 			"tags": map[string]any{
-				"log_level":             "WARN",
-				"log_message":           "Transient error StatusCode.UNAVAILABLE encountered while exporting metrics",
-				"resource_service_name": "loadgenerator",
-				"resource_k8s_pod_name": "otel-demo-loadgenerator-6b44d87f55-kng6x",
+				"level":             "WARN",
+				"message":           "Transient error StatusCode.UNAVAILABLE encountered while exporting metrics",
+				"service": "loadgenerator",
+				"k8s_pod_name": "otel-demo-loadgenerator-6b44d87f55-kng6x",
 			},
 		},
 		tags: map[string]any{
-			"log_level":             "WARN",
-			"log_message":           "Transient error StatusCode.UNAVAILABLE encountered while exporting metrics",
-			"resource_service_name": "loadgenerator",
-			"resource_k8s_pod_name": "otel-demo-loadgenerator-6b44d87f55-kng6x",
+			"level":             "WARN",
+			"message":           "Transient error StatusCode.UNAVAILABLE encountered while exporting metrics",
+			"service": "loadgenerator",
+			"k8s_pod_name": "otel-demo-loadgenerator-6b44d87f55-kng6x",
 		},
 	},
 }
@@ -103,9 +103,8 @@ func TestGetFieldValue(t *testing.T) {
 			message: map[string]any{"timestamp_ns": int64(1771022549165115500)},
 			tags:    nil,
 			field:   "timestamp",
-			// Timestamp formatting is timezone-dependent, so just check format
 			checkFunc: func(s string) bool {
-				return strings.Contains(s, "2026-02-") && strings.Contains(s, ":42:29")
+				return strings.Contains(s, "2026-02-") && strings.Contains(s, ".1651155")
 			},
 		},
 		{
@@ -113,43 +112,42 @@ func TestGetFieldValue(t *testing.T) {
 			message: map[string]any{"timestamp": int64(1771022549165)},
 			tags:    nil,
 			field:   "timestamp",
-			// Timestamp formatting is timezone-dependent, so just check format
 			checkFunc: func(s string) bool {
-				return strings.Contains(s, "2026-02-") && strings.Contains(s, ":42:29.165")
+				return strings.Contains(s, "2026-02-") && strings.HasSuffix(s, ".165")
 			},
 		},
 		{
 			name:     "get level from tags",
 			message:  map[string]any{},
-			tags:     map[string]any{"log_level": "INFO"},
+			tags:     map[string]any{"level": "INFO"},
 			field:    "level",
 			expected: "INFO",
 		},
 		{
 			name:     "get message from tags",
 			message:  map[string]any{},
-			tags:     map[string]any{"log_message": "test message"},
+			tags:     map[string]any{"message": "test message"},
 			field:    "message",
 			expected: "test message",
 		},
 		{
 			name:     "get service from tags",
 			message:  map[string]any{},
-			tags:     map[string]any{"resource_service_name": "cartservice"},
+			tags:     map[string]any{"service": "cartservice"},
 			field:    "service",
 			expected: "cartservice",
 		},
 		{
 			name:     "get svc alias for service",
 			message:  map[string]any{},
-			tags:     map[string]any{"resource_service_name": "myservice"},
+			tags:     map[string]any{"service": "myservice"},
 			field:    "svc",
 			expected: "myservice",
 		},
 		{
 			name:     "get pod from tags",
 			message:  map[string]any{},
-			tags:     map[string]any{"resource_k8s_pod_name": "my-pod-abc123"},
+			tags:     map[string]any{"k8s_pod_name": "my-pod-abc123"},
 			field:    "pod",
 			expected: "my-pod-abc123",
 		},
@@ -332,9 +330,9 @@ func TestFormatJSONEntry(t *testing.T) {
 				"timestamp_ns": int64(1771022549165115500),
 			},
 			tags: map[string]any{
-				"log_level":             "INFO",
-				"log_message":           "test message",
-				"resource_service_name": "testservice",
+				"level":             "INFO",
+				"message":           "test message",
+				"service": "testservice",
 			},
 			cols: []string{"timestamp", "level", "service", "message"},
 		},
@@ -344,9 +342,9 @@ func TestFormatJSONEntry(t *testing.T) {
 				"timestamp_ns": int64(1771022549165115500),
 			},
 			tags: map[string]any{
-				"log_level":             "ERROR",
-				"log_message":           "error occurred",
-				"resource_service_name": "errorservice",
+				"level":             "ERROR",
+				"message":           "error occurred",
+				"service": "errorservice",
 				"trace_id":              "abc123",
 			},
 			cols: []string{"level", "message", "trace_id"},
@@ -390,9 +388,9 @@ func TestFormatJSONEntryValues(t *testing.T) {
 		"timestamp_ns": int64(1771022549165115500),
 	}
 	tags := map[string]any{
-		"log_level":             "INFO",
-		"log_message":           "GetCartAsync called",
-		"resource_service_name": "cartservice",
+		"level":             "INFO",
+		"message":           "GetCartAsync called",
+		"service": "cartservice",
 	}
 
 	result := formatJSONEntry(message, tags, []string{"level", "service", "message"})
@@ -515,39 +513,39 @@ func TestBuildLogQLQuery(t *testing.T) {
 	}{
 		{
 			name:     "no filters",
-			expected: `{resource_service_name=~".+"}`,
+			expected: `{service=~".+"}`,
 		},
 		{
 			name:     "single app",
 			appName:  "cartservice",
-			expected: `{resource_service_name="cartservice"}`,
+			expected: `{service="cartservice"}`,
 		},
 		{
 			name:     "multiple apps",
 			appName:  "cartservice,checkoutservice",
-			expected: `{resource_service_name=~"cartservice|checkoutservice"}`,
+			expected: `{service=~"cartservice|checkoutservice"}`,
 		},
 		{
 			name:     "multiple apps with spaces",
 			appName:  "cartservice, checkoutservice, frontend",
-			expected: `{resource_service_name=~"cartservice|checkoutservice|frontend"}`,
+			expected: `{service=~"cartservice|checkoutservice|frontend"}`,
 		},
 		{
 			name:     "app and level",
 			appName:  "cartservice",
 			logLevel: "ERROR",
-			expected: `{resource_service_name="cartservice", log_level="ERROR"}`,
+			expected: `{service="cartservice", level="ERROR"}`,
 		},
 		{
 			name:     "multiple apps and level",
 			appName:  "cartservice,checkoutservice",
 			logLevel: "ERROR",
-			expected: `{resource_service_name=~"cartservice|checkoutservice", log_level="ERROR"}`,
+			expected: `{service=~"cartservice|checkoutservice", level="ERROR"}`,
 		},
 		{
 			name:     "level only",
 			logLevel: "WARN",
-			expected: `{log_level="WARN"}`,
+			expected: `{level="WARN"}`,
 		},
 		{
 			name:    "custom filter",
@@ -558,31 +556,31 @@ func TestBuildLogQLQuery(t *testing.T) {
 			name:     "app with custom filters",
 			appName:  "cartservice",
 			filters:  []string{"environment:prod", "region:us-west-2"},
-			expected: `{resource_service_name="cartservice", environment="prod", region="us-west-2"}`,
+			expected: `{service="cartservice", environment="prod", region="us-west-2"}`,
 		},
 		{
 			name:            "message contains",
 			appName:         "cartservice",
 			messageContains: "error",
-			expected:        `{resource_service_name="cartservice"} |= "error"`,
+			expected:        `{service="cartservice"} |= "error"`,
 		},
 		{
 			name:               "message not contains",
 			appName:            "cartservice",
 			messageNotContains: "health",
-			expected:           `{resource_service_name="cartservice"} != "health"`,
+			expected:           `{service="cartservice"} != "health"`,
 		},
 		{
 			name:              "message regex match",
 			appName:           "cartservice",
 			messageRegexMatch: "user_id=\\d+",
-			expected:          `{resource_service_name="cartservice"} |~ "user_id=\d+"`,
+			expected:          `{service="cartservice"} |~ "user_id=\d+"`,
 		},
 		{
 			name:            "message regex not",
 			appName:         "cartservice",
 			messageRegexNot: "DEBUG|TRACE",
-			expected:        `{resource_service_name="cartservice"} !~ "DEBUG|TRACE"`,
+			expected:        `{service="cartservice"} !~ "DEBUG|TRACE"`,
 		},
 		{
 			name:               "all message filters",
@@ -591,7 +589,7 @@ func TestBuildLogQLQuery(t *testing.T) {
 			messageNotContains: "health",
 			messageRegexMatch:  "status=\\d+",
 			messageRegexNot:    "DEBUG",
-			expected:           `{resource_service_name="cartservice"} |= "request" != "health" |~ "status=\d+" !~ "DEBUG"`,
+			expected:           `{service="cartservice"} |= "request" != "health" |~ "status=\d+" !~ "DEBUG"`,
 		},
 		{
 			name:     "full complex query",
@@ -599,18 +597,18 @@ func TestBuildLogQLQuery(t *testing.T) {
 			logLevel: "ERROR",
 			filters:  []string{"environment:prod"},
 			messageContains: "timeout",
-			expected: `{resource_service_name=~"cartservice|checkoutservice", log_level="ERROR", environment="prod"} |= "timeout"`,
+			expected: `{service=~"cartservice|checkoutservice", level="ERROR", environment="prod"} |= "timeout"`,
 		},
 		{
 			name:     "empty app entries ignored",
 			appName:  ",,,",
 			logLevel: "ERROR",
-			expected: `{log_level="ERROR"}`,
+			expected: `{level="ERROR"}`,
 		},
 		{
 			name:     "trailing comma in app",
 			appName:  "cartservice,",
-			expected: `{resource_service_name="cartservice"}`,
+			expected: `{service="cartservice"}`,
 		},
 	}
 
@@ -633,57 +631,57 @@ func TestBuildAppCondition(t *testing.T) {
 		{
 			name:     "single app",
 			input:    "cartservice",
-			expected: `resource_service_name="cartservice"`,
+			expected: `service="cartservice"`,
 		},
 		{
 			name:     "single app with leading space",
 			input:    " cartservice",
-			expected: `resource_service_name="cartservice"`,
+			expected: `service="cartservice"`,
 		},
 		{
 			name:     "single app with trailing space",
 			input:    "cartservice ",
-			expected: `resource_service_name="cartservice"`,
+			expected: `service="cartservice"`,
 		},
 		{
 			name:     "two apps",
 			input:    "cartservice,checkoutservice",
-			expected: `resource_service_name=~"cartservice|checkoutservice"`,
+			expected: `service=~"cartservice|checkoutservice"`,
 		},
 		{
 			name:     "three apps",
 			input:    "cartservice,checkoutservice,frontend",
-			expected: `resource_service_name=~"cartservice|checkoutservice|frontend"`,
+			expected: `service=~"cartservice|checkoutservice|frontend"`,
 		},
 		{
 			name:     "apps with spaces",
 			input:    "cartservice, checkoutservice, frontend",
-			expected: `resource_service_name=~"cartservice|checkoutservice|frontend"`,
+			expected: `service=~"cartservice|checkoutservice|frontend"`,
 		},
 		{
 			name:     "single app with dots",
 			input:    "my.service.name",
-			expected: `resource_service_name="my_service_name"`,
+			expected: `service="my_service_name"`,
 		},
 		{
 			name:     "multiple apps with dots",
 			input:    "my.service,another.service",
-			expected: `resource_service_name=~"my_service|another_service"`,
+			expected: `service=~"my_service|another_service"`,
 		},
 		{
 			name:     "mixed dots and underscores",
 			input:    "cart.service,checkout_service",
-			expected: `resource_service_name=~"cart_service|checkout_service"`,
+			expected: `service=~"cart_service|checkout_service"`,
 		},
 		{
 			name:     "trailing comma filtered",
 			input:    "cartservice,",
-			expected: `resource_service_name="cartservice"`,
+			expected: `service="cartservice"`,
 		},
 		{
 			name:     "empty entries filtered",
 			input:    "cartservice,,checkoutservice",
-			expected: `resource_service_name=~"cartservice|checkoutservice"`,
+			expected: `service=~"cartservice|checkoutservice"`,
 		},
 		{
 			name:     "all empty returns empty",

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -210,12 +210,12 @@ func (c *Client) streamResponses(ctx context.Context, httpReq *http.Request) (<-
 
 				if strings.HasPrefix(line, "data: ") {
 					data := strings.TrimPrefix(line, "data: ")
-					if data == `{"type":"done"}` {
-						return
-					}
 					var response LogsResponse
 					if err := json.Unmarshal([]byte(data), &response); err != nil {
 						continue
+					}
+					if response.Type == "done" {
+						return
 					}
 					select {
 					case responseChan <- response:

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -92,7 +92,7 @@ func ResolveFilters(filters []string) ([]string, error) {
 
 // RegisterAliasFlags registers user-defined aliases as CLI flags on the given command.
 // Single-char aliases become short flags (e.g., -i for resource_installation).
-// Multi-char aliases become long flags (e.g., --svc for resource_service_name).
+// Multi-char aliases become long flags (e.g., --svc for service_name).
 // Returns a map of fullKey -> value pointer for use with CollectAliasFilters.
 func RegisterAliasFlags(cmd *cobra.Command) map[string]*string {
 	cfg, err := Load()


### PR DESCRIPTION
## Summary

Validating the CLI against a live Lakerunner deployment surfaced two issues that together made `lakerunner-cli logs get` unusable end-to-end:

- **Field naming drift.** `buildAppCondition`, `buildLogQLQuery`, `getFieldValue`, the text-mode formatter, and the attributes/tagvalues query builders were still using the legacy field names (`resource_service_name`, `log_level`, `log_message`, `resource_k8s_pod_name`, `_cardinalhq_level`). Current Lakerunner rows expose the flat names `service`, `level`, `message`, `k8s_pod_name`, so every query filtered to zero results and every rendered row printed empty `level`/`service`/`message`/`pod` cells. Updated all references (plus the mock fixtures and query-builder tests) to the current names.
- **Stray "done" row.** SSE completion events now carry a payload (`{"type":"done","data":{"status":"ok"}}`) instead of the bare `{"type":"done"}` the client was string-matching on, so the terminator was leaking through as an empty log entry. Detect completion after unmarshaling via `response.Type == "done"` instead.

Also loosened a timezone-sensitive timestamp assertion in `get_test.go` so tests pass outside UTC.

## Test plan

- [x] `make check` (go test -race, license-check, golangci-lint) — clean
- [x] `lakerunner-cli logs get --limit 3` returns rows with populated timestamp/level/service/message (was blank before)
- [x] `logs get -a <svc> -l ERROR` returns the expected ERROR rows
- [x] `logs get -o json`, `-o csv`, `-o tsv` render correctly
- [x] `logs get -M`, `-N`, `-R`, `-X` message filters
- [x] `logs get --order oldest`, custom `--columns`, `--query`
- [x] `logs get-attr` and `logs get-values <tag>` return values
- [x] `presets list` and `aliases list`
- [x] `--endpoint` / `--api-key` flag overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)