### PR TITLE
Wire get-attr filters through to the API; drop unused --verbose

### DIFF
--- a/cmd/logs/attributes.go
+++ b/cmd/logs/attributes.go
@@ -29,13 +29,14 @@ import (
 )
 
 var (
-	attributesFilters    []string
-	attributesPreset     string
-	attributesStartTime  string
-	attributesEndTime    string
-	attributesAppName    string
-	attributesLogLevel   string
-	tagValuesAliasValues map[string]*string
+	attributesFilters      []string
+	attributesPreset       string
+	attributesStartTime    string
+	attributesEndTime      string
+	attributesAppName      string
+	attributesLogLevel     string
+	attributesAliasValues  map[string]*string
+	tagValuesAliasValues   map[string]*string
 )
 
 var AttributesCmd = &cobra.Command{
@@ -68,7 +69,7 @@ func init() {
 	TagValuesCmd.Flags().StringVarP(&attributesEndTime, "end", "e", "", "End time (e.g., 'now', '2024-01-01T23:59:59Z')")
 	TagValuesCmd.Flags().StringVarP(&attributesAppName, "app", "a", "", "Filter by application/service name")
 	TagValuesCmd.Flags().StringVarP(&attributesLogLevel, "level", "l", "", "Filter by log level (e.g., ERROR, INFO, DEBUG, WARN)")
-	presets.RegisterAliasFlags(AttributesCmd)
+	attributesAliasValues = presets.RegisterAliasFlags(AttributesCmd)
 	tagValuesAliasValues = presets.RegisterAliasFlags(TagValuesCmd)
 }
 
@@ -90,15 +91,40 @@ func runAttributesCmd(cmdObj *cobra.Command, _ []string) error {
 	startTimeStr := fmt.Sprintf("%d", startMs)
 	endTimeStr := fmt.Sprintf("%d", endMs)
 
+	// Assemble filter set from preset + -f flags + alias flags (same rules as `logs get`).
+	allFilters := attributesFilters
+	if attributesPreset != "" {
+		presetFilters, err := presets.GetFilters(attributesPreset)
+		if err != nil {
+			return err
+		}
+		allFilters = append(presetFilters, attributesFilters...)
+	}
+	allFilters, err = presets.ResolveFilters(allFilters)
+	if err != nil {
+		return err
+	}
+	allFilters = append(allFilters, presets.CollectAliasFilters(attributesAliasValues)...)
+
+	// Build LogQL selector. Empty string means "all logs" — the server takes the fast DB path.
+	var q string
+	if attributesAppName != "" || attributesLogLevel != "" || len(allFilters) > 0 {
+		q = buildLogQLQuery(attributesAppName, attributesLogLevel, allFilters, "", "", "", "")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	responseChan, err := client.QueryLogTags(ctx, startTimeStr, endTimeStr)
+	responseChan, err := client.QueryLogTags(ctx, q, startTimeStr, endTimeStr)
 	if err != nil {
 		return fmt.Errorf("failed to query tags: %w", err)
 	}
 
-	fmt.Printf("Querying tags from %s to %s...\n", startTimeStr, endTimeStr)
+	fmt.Printf("Querying tags from %s to %s", startTimeStr, endTimeStr)
+	if q != "" {
+		fmt.Printf(" with query %s", q)
+	}
+	fmt.Println("...")
 	fmt.Println("---")
 
 	tagsSet := make(map[string]bool)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,6 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "suppress informational output")
 	rootCmd.PersistentFlags().Bool("no-color", false, "disable colored output")
 	rootCmd.PersistentFlags().String("endpoint", "", "API endpoint URL (overrides LAKERUNNER_QUERY_URL)")

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -101,13 +101,17 @@ func (c *Client) QueryLogs(
 	return c.streamResponses(ctx, httpReq)
 }
 
-// QueryLogTags makes a request to tags query and returns a json response
-func (c *Client) QueryLogTags(ctx context.Context, s string, e string) (<-chan LogsResponse, error) {
+// QueryLogTags makes a request to tags query and returns a json response.
+// If q is non-empty, the returned tag list is scoped to logs matching the LogQL selector.
+func (c *Client) QueryLogTags(ctx context.Context, q, s, e string) (<-chan LogsResponse, error) {
 	url := c.baseURL + "/api/v1/logs/tags"
 
 	body := map[string]interface{}{
 		"s": s,
 		"e": e,
+	}
+	if q != "" {
+		body["q"] = q
 	}
 	jsonData, err := json.Marshal(body)
 	if err != nil {


### PR DESCRIPTION
## Summary

Thorough validation against a running Lakerunner surfaced two more gaps:

**`logs get-attr` silently ignored its filter flags.** The command advertised `--app` / `--level` / `--filter` / `--preset` (and any alias flags), but `runAttributesCmd` never built a LogQL selector and `Client.QueryLogTags` never sent a `q` parameter. The `/api/v1/logs/tags` handler already supports `q` — with it, the server scopes the returned tag list to attributes present on matching rows; without it, you always got the full org-wide list. Wire the client to pass `q` and build the selector in `runAttributesCmd` using the same rules as `logs get` (preset filters first, then `-f`, then alias-flag filters; aliases resolved). An empty filter set still takes the fast DB-only path in the API.

**`--verbose` was a lie.** Declared as a persistent flag on root, but no code path ever read it (`grep -rn 'GetBool("verbose")'` returns nothing). Dropped rather than leave a non-functional flag in `--help` and the docs.

## Test plan

Validated with a fresh port-forward + temp API key against prod:

- `logs get-attr -s e-30m` — 616 tags (org-wide, DB-only path)
- `logs get-attr -a cart-service -s e-30m` — 30 tags (scoped)
- `logs get-attr -l ERROR -s e-30m` — 40 tags (scoped)
- `logs get-attr -f service:cart-service -s e-30m` — header now prints `with query {service="cart-service"}`
- `--verbose` now errors as an unknown flag (as intended)
- `make check` (go test -race + license-eye + golangci-lint) clean

Docs update in [cardinal-docs #(pending)](https://github.com/cardinalhq/cardinal-docs/pull/new/docs/lakerunner-cli-remove-verbose-and-getattr-filters) drops `--verbose` from the global-flags table and adds a note on how `get-attr` scopes results when filters are provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)