### PR TITLE
Add Claude Code skill for querying logs via the CLI

### DIFF
--- a/.claude/skills/lakerunner-cli/SKILL.md
+++ b/.claude/skills/lakerunner-cli/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: lakerunner-cli
+description: Query S3 logs through the Lakerunner CLI. Use when the user wants to search, filter, or export logs; discover available attributes; or answer questions about log volume, error rates, or specific services from data stored via Lakerunner.
+---
+
+# Lakerunner CLI skill
+
+You have access to `lakerunner-cli` on this machine. Use it to answer log-related questions instead of guessing.
+
+Full reference: https://docs.cardinalhq.io/lakerunner/cli
+
+## Before you run anything
+
+1. Confirm the binary is on `PATH`: `command -v lakerunner-cli`. If missing, tell the user to install it from https://github.com/cardinalhq/lakerunner-cli/releases and stop.
+2. Confirm credentials are set: `LAKERUNNER_QUERY_URL` and `LAKERUNNER_API_KEY` must be in the environment. If either is missing, ask the user before proceeding — don't invent an endpoint.
+3. Default to `--quiet` in scripted/agentic use so the banner doesn't pollute output you'll parse.
+4. Default to `--output json` when you're going to parse or reason about the data. Reserve `text` for cases where the user asked to see the logs directly.
+
+## Commands you'll actually use
+
+### `lakerunner-cli logs get` — the primary query
+
+Returns log rows. Defaults: last 1 hour, 1000 rows, newest first.
+
+Flags worth knowing:
+
+- `-s / --start`, `-e / --end` — time bounds. Accepts relative (`e-1h`, `e-30m`, `now`) or ISO 8601 (`2024-01-01T00:00:00Z`). Relative bounds anchor to `end`, not to wall-clock now — so if you change `--end`, `e-1h` moves with it.
+- `-a / --app` — filter by service name. Comma-separated for multiple: `-a "api,auth"`.
+- `-l / --level` — `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`.
+- `-f / --filter` — repeatable `key:value` filters (`-f "environment:prod" -f "region:us-east-1"`).
+- `-p / --preset` — named filter set from `~/.lakerunner/config.yaml`.
+- `-M / --contains`, `-N / --not-contains` — plain substring match on the message.
+- `-R / --msg-regex`, `-X / --msg-not-regex` — regex match on the message.
+- `-c / --columns` — comma-separated columns. Shortcuts: `timestamp`/`ts`, `level`, `service`/`svc`, `pod`, `message`. Any raw attribute name also works.
+- `-o / --output` — `text` | `json` | `csv` | `tsv`.
+- `--order` — `newest` (default) or `oldest`.
+- `--limit` — cap on rows (default 1000). Raise deliberately; don't request millions.
+- `--query` — a raw LogQL query. Bypasses the structured flags. Only use when the user hands you one or when the structured flags can't express what they want.
+
+Preset filters are applied first, then `--filter` values are appended.
+
+### `lakerunner-cli logs get-attr` — discover fields
+
+Lists attribute names available for a given time range. With no filters this is a fast metadata lookup; with any filter flag the returned list is scoped to attributes actually attached to matching rows. Same time/filter flags as `logs get`.
+
+Use this when the user asks "what can I filter by?" or before crafting a complex filter on unfamiliar data.
+
+### `lakerunner-cli logs get-values <attr>` — enumerate values
+
+Returns the observed values for a single attribute. Same time/filter flags as `logs get-attr`. Use this to answer "what services do we have?", "which environments?", etc.
+
+### `lakerunner-cli presets list` and `lakerunner-cli aliases list`
+
+Show what's configured in `~/.lakerunner/config.yaml`. Check these before writing a long `-f` chain — the user may already have a preset.
+
+## Patterns
+
+**Answering "any errors in the last hour?"**
+
+```bash
+lakerunner-cli --quiet logs get -l ERROR -s e-1h -o json --limit 200
+```
+Then summarize by service and message shape.
+
+**Answering "why is service X failing?"**
+
+1. `lakerunner-cli --quiet logs get -a X -l ERROR -o json --limit 500`
+2. Group by message pattern, pick the top offenders, report counts + a sample line.
+
+**Exploring unfamiliar data:**
+
+1. `lakerunner-cli --quiet logs get-attr -s e-24h` — see what fields exist.
+2. `lakerunner-cli --quiet logs get-values service -s e-24h` — see the service catalog.
+3. Then narrow.
+
+**Exporting for the user:**
+
+Use `-o csv` or `-o json` and either redirect to a file the user names or print a short preview and ask where to save it. Don't dump 10k rows into chat.
+
+## Guardrails
+
+- **Never fabricate log lines.** If a query returns nothing, say so.
+- **Don't guess time ranges.** If the user says "recently" and there's ambiguity, ask, or default to `e-1h` and state your assumption.
+- **Don't invent attribute names.** Run `logs get-attr` first if you aren't sure a field exists.
+- **Don't run unbounded exports.** Ask before raising `--limit` above ~10k or pulling multi-day ranges.
+- **Redact obvious secrets** (tokens, keys, passwords) from any log content you paste back into chat.
+- If the CLI errors, show the exact error to the user rather than retrying blindly.
+
+## Quick smoke test
+
+If you're not sure the setup works, run:
+
+```bash
+lakerunner-cli --quiet logs get -s e-5m --limit 5 -o json
+```
+
+A JSON array (possibly empty) means you're wired up.

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,13 @@ test-only:
 
 
 #
+# Install the Claude Code skill into ~/.claude/skills/
+#
+.PHONY: install-skill
+install-skill:
+	./scripts/install-claude-skill.sh
+
+#
 # promode to prod
 #
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ lakerunner logs get -s e-24h --limit 50000 -o csv > yesterday.csv
 
 See the [full CLI reference](https://docs.cardinalhq.io/lakerunner/cli) for all flags, output formats, presets, aliases, and more.
 
+## Claude Code skill
+
+If you use [Claude Code](https://docs.claude.com/en/docs/claude-code/overview), install the bundled skill so Claude can query your logs on your behalf:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/cardinalhq/lakerunner-cli/main/scripts/install-claude-skill.sh | bash
+```
+
+Or, from a checkout: `make install-skill`.
+
+Once installed, type `/lakerunner-cli` in Claude Code. See the [skill docs](https://docs.cardinalhq.io/lakerunner/claude-skill) for details.
+
 ## Building from source
 
 Requires Go 1.24+.

--- a/scripts/install-claude-skill.sh
+++ b/scripts/install-claude-skill.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright 2025-2026 CardinalHQ, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Installs the lakerunner-cli Claude Code skill into ~/.claude/skills/.
+#
+# Usage (from a checkout):
+#   bash scripts/install-claude-skill.sh
+#
+# Usage (one-liner, no checkout):
+#   curl -fsSL https://raw.githubusercontent.com/cardinalhq/lakerunner-cli/main/scripts/install-claude-skill.sh | bash
+
+set -euo pipefail
+
+SKILL_NAME="lakerunner-cli"
+SKILL_URL="https://raw.githubusercontent.com/cardinalhq/lakerunner-cli/main/.claude/skills/${SKILL_NAME}/SKILL.md"
+
+SKILLS_ROOT="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
+TARGET_DIR="${SKILLS_ROOT}/${SKILL_NAME}"
+TARGET_FILE="${TARGET_DIR}/SKILL.md"
+
+# Prefer the local copy when running from a checkout; otherwise fetch.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_SKILL="${SCRIPT_DIR}/../.claude/skills/${SKILL_NAME}/SKILL.md"
+
+mkdir -p "${TARGET_DIR}"
+
+if [[ -f "${LOCAL_SKILL}" ]]; then
+  cp "${LOCAL_SKILL}" "${TARGET_FILE}"
+  echo "Installed ${SKILL_NAME} skill from local checkout → ${TARGET_FILE}"
+else
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "error: curl is required to fetch the skill" >&2
+    exit 1
+  fi
+  curl -fsSL "${SKILL_URL}" -o "${TARGET_FILE}"
+  echo "Installed ${SKILL_NAME} skill from ${SKILL_URL} → ${TARGET_FILE}"
+fi
+
+cat <<EOF
+
+Next steps:
+  1. Make sure lakerunner-cli is on your PATH.
+  2. Export LAKERUNNER_QUERY_URL and LAKERUNNER_API_KEY.
+  3. In Claude Code, type /${SKILL_NAME} to invoke the skill.
+
+Uninstall with: rm -rf "${TARGET_DIR}"
+EOF


### PR DESCRIPTION
## Summary
- Ships `.claude/skills/lakerunner-cli/SKILL.md` — a Claude Code skill that teaches Claude when and how to invoke `lakerunner-cli` to answer log questions (defaults to `--quiet --output json` for parsing, prefers `logs get-attr` / `logs get-values` for discovery, guards against fabrication and unbounded exports).
- Adds `scripts/install-claude-skill.sh` and a `make install-skill` target that drop the skill into `~/.claude/skills/` (respects `CLAUDE_SKILLS_DIR`).
- README picks up a curl one-liner so users can install without a checkout.

Companion docs PR: cardinalhq/cardinal-docs (adds `/lakerunner/claude-skill`).

## Test plan
- [x] `./tools/license-eye header check` passes
- [x] Installer smoke-tested with `CLAUDE_SKILLS_DIR=...` against a scratch dir — copies `SKILL.md` correctly from the local checkout
- [ ] After merge: run the curl one-liner to confirm it fetches from `main`