### PR TITLE
Prompt for Lakerunner credentials during skill install

### DIFF
--- a/scripts/install-claude-skill.sh
+++ b/scripts/install-claude-skill.sh
@@ -48,12 +48,117 @@ else
   echo "Installed ${SKILL_NAME} skill from ${SKILL_URL} → ${TARGET_FILE}"
 fi
 
+# Prompt for credentials so users don't have to look them up separately.
+# Both values are deployment-specific — the CLI talks to whatever Lakerunner
+# instance the user runs (in-VPC, self-hosted, etc.), so we can't derive them.
+prompt_for_creds() {
+  if [[ ! -t 0 || ! -t 1 ]]; then
+    # Non-interactive (piped install). Skip prompts; fall back to the reminder.
+    return 1
+  fi
+
+  echo
+  echo "Configure Lakerunner credentials for the skill."
+  echo "Get these from whoever runs your Lakerunner deployment (or the deployment's"
+  echo "own docs/console). Leave blank to skip and set them yourself later."
+  echo
+
+  local existing_url="${LAKERUNNER_QUERY_URL:-}"
+  local existing_key="${LAKERUNNER_API_KEY:-}"
+  local url_prompt="LAKERUNNER_QUERY_URL"
+  local key_prompt="LAKERUNNER_API_KEY"
+  [[ -n "${existing_url}" ]] && url_prompt+=" [${existing_url}]"
+  [[ -n "${existing_key}" ]] && key_prompt+=" [****${existing_key: -4}]"
+
+  local url key
+  printf "  %s: " "${url_prompt}"
+  IFS= read -r url || return 1
+  printf "  %s: " "${key_prompt}"
+  # -s hides the key echo; add a newline afterwards.
+  IFS= read -rs key || return 1
+  echo
+
+  url="${url:-${existing_url}}"
+  key="${key:-${existing_key}}"
+
+  if [[ -z "${url}" && -z "${key}" ]]; then
+    return 1
+  fi
+
+  LR_URL="${url}"
+  LR_KEY="${key}"
+  return 0
+}
+
+persist_creds() {
+  local url="$1" key="$2"
+  local profile=""
+  case "${SHELL:-}" in
+    */zsh)  profile="${HOME}/.zshrc" ;;
+    */bash) profile="${HOME}/.bashrc" ;;
+    */fish) profile="${HOME}/.config/fish/config.fish" ;;
+  esac
+
+  echo
+  if [[ -z "${profile}" ]]; then
+    echo "Couldn't detect a shell profile from \$SHELL=${SHELL:-}. Add these lines yourself:"
+    [[ -n "${url}" ]] && echo "  export LAKERUNNER_QUERY_URL=\"${url}\""
+    [[ -n "${key}" ]] && echo "  export LAKERUNNER_API_KEY=\"${key}\""
+    return
+  fi
+
+  printf "Append export lines to %s? [y/N] " "${profile}"
+  local answer
+  IFS= read -r answer || answer=""
+  if [[ ! "${answer}" =~ ^[Yy]$ ]]; then
+    echo "Skipped. To set them yourself:"
+    [[ -n "${url}" ]] && echo "  export LAKERUNNER_QUERY_URL=\"${url}\""
+    [[ -n "${key}" ]] && echo "  export LAKERUNNER_API_KEY=\"${key}\""
+    return
+  fi
+
+  {
+    echo ""
+    echo "# Added by lakerunner-cli install-claude-skill.sh"
+    if [[ "${profile}" == *config.fish ]]; then
+      [[ -n "${url}" ]] && echo "set -gx LAKERUNNER_QUERY_URL \"${url}\""
+      [[ -n "${key}" ]] && echo "set -gx LAKERUNNER_API_KEY \"${key}\""
+    else
+      [[ -n "${url}" ]] && echo "export LAKERUNNER_QUERY_URL=\"${url}\""
+      [[ -n "${key}" ]] && echo "export LAKERUNNER_API_KEY=\"${key}\""
+    fi
+  } >> "${profile}"
+  echo "Wrote credentials to ${profile}. Open a new shell (or 'source ${profile}') to pick them up."
+}
+
+LR_URL=""
+LR_KEY=""
+if prompt_for_creds; then
+  persist_creds "${LR_URL}" "${LR_KEY}"
+  CREDS_DONE=1
+else
+  CREDS_DONE=0
+fi
+
 cat <<EOF
 
 Next steps:
   1. Make sure lakerunner-cli is on your PATH.
-  2. Export LAKERUNNER_QUERY_URL and LAKERUNNER_API_KEY.
+EOF
+
+if [[ "${CREDS_DONE}" -eq 0 ]]; then
+  cat <<EOF
+  2. Set LAKERUNNER_QUERY_URL and LAKERUNNER_API_KEY in your environment
+     (values come from your Lakerunner deployment — ask whoever runs it).
   3. In Claude Code, type /${SKILL_NAME} to invoke the skill.
+EOF
+else
+  cat <<EOF
+  2. In Claude Code, type /${SKILL_NAME} to invoke the skill.
+EOF
+fi
+
+cat <<EOF
 
 Uninstall with: rm -rf "${TARGET_DIR}"
 EOF


### PR DESCRIPTION
## Summary
- The Claude Code skill install script now interactively prompts for `LAKERUNNER_QUERY_URL` and `LAKERUNNER_API_KEY` so users don't have to hunt for them after install.
- Offers to persist the values to the detected shell profile (zsh/bash/fish); otherwise prints copy-pasteable `export` lines.
- Non-interactive (piped) installs are unchanged — they fall back to the existing "set these env vars yourself" reminder.
- Guidance is deployment-agnostic (no k8s specifics), since the CLI runs against whatever Lakerunner deployment the user has.

## Test plan
- [ ] Piped install: `curl … | bash` still installs the skill and prints the reminder.
- [ ] Interactive install: prompts appear, API key input is hidden, values land in the chosen shell profile.
- [ ] Decline the profile write: exports are printed for manual paste.
- [ ] Unknown `$SHELL`: script prints exports and exits cleanly.