### PR TITLE
docs: point skill link at nested URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl -fsSL https://raw.githubusercontent.com/cardinalhq/lakerunner-cli/main/scri
 
 Or, from a checkout: `make install-skill`.
 
-Once installed, type `/lakerunner-cli` in Claude Code. See the [skill docs](https://docs.cardinalhq.io/lakerunner/claude-skill) for details.
+Once installed, type `/lakerunner-cli` in Claude Code. See the [skill docs](https://docs.cardinalhq.io/lakerunner/cli/claude-skill) for details.
 
 ## Building from source
 


### PR DESCRIPTION
## Summary
- README link to the Claude Code skill docs now points at `/lakerunner/cli/claude-skill` to match the docs restructure (cardinalhq/cardinal-docs#66) that nests the skill under CLI Reference.

## Test plan
- [ ] Once cardinal-docs #66 is deployed, the link resolves.