### PR TITLE
Add --insecure flag to skip TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ export LAKERUNNER_QUERY_URL=http://localhost:7101
 export LAKERUNNER_API_KEY=your-api-key
 ```
 
+If your endpoint uses a self-signed certificate (e.g. a CloudFormation install
+whose ALB has no real cert), pass `--insecure` or set `LAKERUNNER_INSECURE=1` to
+skip TLS verification (equivalent to `curl -k`).
+
 **Windows (PowerShell):**
 
 ```powershell

--- a/cmd/logs/attributes.go
+++ b/cmd/logs/attributes.go
@@ -78,7 +78,8 @@ func runAttributesCmd(cmdObj *cobra.Command, _ []string) error {
 
 	endpoint, _ := cmdObj.Flags().GetString("endpoint")
 	apiKey, _ := cmdObj.Flags().GetString("api-key")
-	cfg, err := config.LoadWithFlags(endpoint, apiKey)
+	insecure, _ := cmdObj.Flags().GetBool("insecure")
+	cfg, err := config.LoadWithFlags(endpoint, apiKey, insecure)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -161,7 +162,8 @@ func runTagValuesCmd(cmdObj *cobra.Command, args []string) error {
 
 	endpoint, _ := cmdObj.Flags().GetString("endpoint")
 	apiKey, _ := cmdObj.Flags().GetString("api-key")
-	cfg, err := config.LoadWithFlags(endpoint, apiKey)
+	insecure, _ := cmdObj.Flags().GetBool("insecure")
+	cfg, err := config.LoadWithFlags(endpoint, apiKey, insecure)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}

--- a/cmd/logs/get.go
+++ b/cmd/logs/get.go
@@ -311,7 +311,8 @@ func runGetCmd(cmdObj *cobra.Command, _ []string) error {
 
 	endpoint, _ := cmdObj.Flags().GetString("endpoint")
 	apiKey, _ := cmdObj.Flags().GetString("api-key")
-	cfg, err := config.LoadWithFlags(endpoint, apiKey)
+	insecure, _ := cmdObj.Flags().GetBool("insecure")
+	cfg, err := config.LoadWithFlags(endpoint, apiKey, insecure)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("no-color", false, "disable colored output")
 	rootCmd.PersistentFlags().String("endpoint", "", "API endpoint URL (overrides LAKERUNNER_QUERY_URL)")
 	rootCmd.PersistentFlags().String("api-key", "", "API key (overrides LAKERUNNER_API_KEY)")
+	rootCmd.PersistentFlags().Bool("insecure", false, "skip TLS certificate verification (for self-signed endpoints; overrides LAKERUNNER_INSECURE)")
 
 	rootCmd.AddCommand(logs.LogsCmd)
 	rootCmd.AddCommand(demo.DemoCmd)

--- a/env.example
+++ b/env.example
@@ -4,3 +4,6 @@
 # API Configuration
 LAKERUNNER_QUERY_URL=https://api.lakerunner.com/v1
 LAKERUNNER_API_KEY=your_api_key_here 
+
+# Skip TLS certificate verification (self-signed endpoints only; equivalent to curl -k)
+# LAKERUNNER_INSECURE=1

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -47,6 +48,7 @@ func NewClient(cfg *config.Config) *Client {
 				MaxIdleConns:       10,
 				IdleConnTimeout:    60 * time.Second,
 				DisableCompression: false,
+				TLSClientConfig:    &tls.Config{InsecureSkipVerify: cfg.Insecure}, //nolint:gosec // opt-in via --insecure for self-signed endpoints
 			},
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/joho/godotenv"
 )
@@ -24,6 +25,10 @@ import (
 type Config struct {
 	LAKERUNNER_QUERY_URL string
 	LAKERUNNER_API_KEY   string
+	// Insecure skips TLS certificate verification. Use only for endpoints
+	// with a self-signed certificate (e.g. a CloudFormation install whose
+	// ALB has no real cert). Equivalent to curl -k.
+	Insecure bool
 }
 
 func Load() (*Config, error) {
@@ -33,18 +38,20 @@ func Load() (*Config, error) {
 	cfg := &Config{
 		LAKERUNNER_QUERY_URL: getEnv("LAKERUNNER_QUERY_URL", ""),
 		LAKERUNNER_API_KEY:   getEnv("LAKERUNNER_API_KEY", ""),
+		Insecure:             getEnvBool("LAKERUNNER_INSECURE"),
 	}
 	return cfg, cfg.Validate()
 }
 
 // LoadWithFlags loads configuration with optional flag overrides
-func LoadWithFlags(endpointFlag, apiKeyFlag string) (*Config, error) {
+func LoadWithFlags(endpointFlag, apiKeyFlag string, insecureFlag bool) (*Config, error) {
 	// Try to load .env file, but don't fail if it doesn't exist
 	_ = godotenv.Load()
 
 	cfg := &Config{
 		LAKERUNNER_QUERY_URL: getEnvOrFlag("LAKERUNNER_QUERY_URL", endpointFlag),
 		LAKERUNNER_API_KEY:   getEnvOrFlag("LAKERUNNER_API_KEY", apiKeyFlag),
+		Insecure:             insecureFlag || getEnvBool("LAKERUNNER_INSECURE"),
 	}
 	return cfg, cfg.Validate()
 }
@@ -62,6 +69,13 @@ func getEnvOrFlag(envKey, flagValue string) string {
 		return flagValue
 	}
 	return getEnv(envKey, "")
+}
+
+// getEnvBool parses a boolean environment variable (e.g. "1", "true"); unset or
+// unparseable is false.
+func getEnvBool(key string) bool {
+	v, err := strconv.ParseBool(os.Getenv(key))
+	return err == nil && v
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
## What

Adds an opt-in way to skip TLS certificate verification, so the CLI can talk to endpoints with a self-signed certificate.

- `--insecure` persistent flag
- `LAKERUNNER_INSECURE=1` env var (flag takes precedence)

Equivalent to `curl -k`. Off by default — normal TLS verification is unchanged.

## Why

A Lakerunner CloudFormation install auto-generates a self-signed cert for its ALB when no ACM/IAM cert is supplied. The CLI's Go `net/http` client rejects that (`x509: certificate signed by unknown authority`) and had no way to bypass it — `SSL_CERT_FILE` is ignored by the platform verifier on macOS. This closes that gap for dev/test installs.

## Test

```
# default: fails TLS (secure by default)
lakerunner logs get ...                 -> x509: certificate signed by unknown authority
# opt-in via flag or env: works
lakerunner logs get ... --insecure      -> query executes
LAKERUNNER_INSECURE=1 lakerunner ...     -> query executes
```

Verified end-to-end against a live self-signed ALB endpoint. `go build`, `go vet`, `go test ./...` all pass.